### PR TITLE
Use working (v2) API URL, update specs to use new syntax

### DIFF
--- a/lib/lita/handlers/time.rb
+++ b/lib/lita/handlers/time.rb
@@ -1,7 +1,7 @@
 module Lita
   module Handlers
     class Time < Handler
-      URL = "http://api.worldweatheronline.com/free/v1/tz.ashx"
+      URL = "http://api.worldweatheronline.com/free/v2/tz.ashx"
 
       route(/(?:what\s)?time(?:\sis\sit)?(?:\sin)?\s([^\?]+)(?:\?)?/, :fetch, command: true, help: {
         t("help.time_key") => t("help.time_value")

--- a/spec/lita/handlers/time_spec.rb
+++ b/spec/lita/handlers/time_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 
 describe Lita::Handlers::Time, lita_handler: true do
 
-  it { routes_command("time Mableton, GA").to(:fetch) }
-  it { routes_command("time Mableton, GA?").to(:fetch) }
-  it { routes_command("time in Mableton, GA").to(:fetch) }
-  it { routes_command("time in Mableton, GA?").to(:fetch) }
-  it { routes_command("what time in Mableton, GA").to(:fetch) }
-  it { routes_command("what time in Mableton, GA?").to(:fetch) }
-  it { routes_command("what time is it in Mableton, GA").to(:fetch) }
-  it { routes_command("what time is it in Mableton, GA?").to(:fetch) }
+  it { is_expected.to route_command("time Mableton, GA").to(:fetch) }
+  it { is_expected.to route_command("time Mableton, GA?").to(:fetch) }
+  it { is_expected.to route_command("time in Mableton, GA").to(:fetch) }
+  it { is_expected.to route_command("time in Mableton, GA?").to(:fetch) }
+  it { is_expected.to route_command("what time in Mableton, GA").to(:fetch) }
+  it { is_expected.to route_command("what time in Mableton, GA?").to(:fetch) }
+  it { is_expected.to route_command("what time is it in Mableton, GA").to(:fetch) }
+  it { is_expected.to route_command("what time is it in Mableton, GA?").to(:fetch) }
 
   describe "#fetch" do
     let(:response) { double("Faraday::Response") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,4 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "lita-time"
 require "lita/rspec"
+Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
The old v1 URL doesn't seem to return a proper response anymore. I updated the specs to use the new Lita helper syntax.