### PR TITLE
avoid an exception when the API response isn't JSON

### DIFF
--- a/lib/lita/handlers/time.rb
+++ b/lib/lita/handlers/time.rb
@@ -23,9 +23,8 @@ module Lita
           format: 'json'
         )
 
-        data = MultiJson.load(http_response.body)["data"]
-
         begin
+          data = MultiJson.load(http_response.body)["data"]
           type  = data['request'][0]['type']
           query = data['request'][0]['query']
           time  = data['time_zone'][0]['localtime'].split(/ /)[1]

--- a/lib/lita/handlers/time.rb
+++ b/lib/lita/handlers/time.rb
@@ -29,6 +29,8 @@ module Lita
           query = data['request'][0]['query']
           time  = data['time_zone'][0]['localtime'].split(/ /)[1]
           response.reply t("response.success", :type => type, :query => query, :time => time)
+        rescue MultiJson::ParseError
+          response.reply t("response.json_failure", :location => location)
         rescue
           response.reply t("response.failure", :location => location)
         end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,3 +8,4 @@ en:
         response:
           success: "The current time for the %{type} of %{query} is %{time}"
           failure: "Sorry, couldn't find %{location}"
+          json_failure: "Error parsing API response for %{location}"

--- a/spec/lita/handlers/time_spec.rb
+++ b/spec/lita/handlers/time_spec.rb
@@ -64,5 +64,14 @@ JSON
         "Sorry, couldn't find not a real place"
       )
     end
+
+    it "replies with a helpful message when the API returns non-JSON" do
+      allow(response).to receive(:body).and_return("")
+
+      send_command("time Mableton, GA")
+      expect(replies.last).to eq(
+        "Sorry, couldn't find Mableton, GA"
+      )
+    end
   end
 end

--- a/spec/lita/handlers/time_spec.rb
+++ b/spec/lita/handlers/time_spec.rb
@@ -70,7 +70,7 @@ JSON
 
       send_command("time Mableton, GA")
       expect(replies.last).to eq(
-        "Sorry, couldn't find Mableton, GA"
+        "Error parsing API response for Mableton, GA"
       )
     end
   end


### PR DESCRIPTION
Yesterday, `api.worldweatheronline.com` was temporarily returning errors with a non-JSON body.

Rather than crash the bot, it might be nicer to catch the exception and return a (somewhat) helpful message to the user.