### PR TITLE
avoid routing any sentence that contains the word 'time'

### DIFF
--- a/lib/lita/handlers/time.rb
+++ b/lib/lita/handlers/time.rb
@@ -3,7 +3,7 @@ module Lita
     class Time < Handler
       URL = "http://api.worldweatheronline.com/free/v2/tz.ashx"
 
-      route(/(?:what\s)?time(?:\sis\sit)?(?:\sin)?\s([^\?]+)(?:\?)?/, :fetch, command: true, help: {
+      route(/\A(?:what\s)?time(?:\sis\sit)?(?:\sin)?\s([^\?]+)(?:\?)?/, :fetch, command: true, help: {
         t("help.time_key") => t("help.time_value")
       })
 

--- a/spec/lita/handlers/time_spec.rb
+++ b/spec/lita/handlers/time_spec.rb
@@ -10,6 +10,7 @@ describe Lita::Handlers::Time, lita_handler: true do
   it { is_expected.to route_command("what time in Mableton, GA?").to(:fetch) }
   it { is_expected.to route_command("what time is it in Mableton, GA").to(:fetch) }
   it { is_expected.to route_command("what time is it in Mableton, GA?").to(:fetch) }
+  it { is_expected.to_not route_command("I think it's time for lunch") }
 
   describe "#fetch" do
     let(:response) { double("Faraday::Response") }


### PR DESCRIPTION
We noticed that this handler was a little eager and would lookup the the time in `for lunch` when someone says: `I think it's time for lunch`.

To solve it, I prepended `\A` to the route so it'll only match commands that start with `time` or `what time`.
